### PR TITLE
add missing import

### DIFF
--- a/isatools/convert/isatab2sra.py
+++ b/isatools/convert/isatab2sra.py
@@ -5,6 +5,7 @@ from zipfile import ZipFile
 import logging
 from isatools import isatab
 import json
+import glob
 from io import StringIO
 
 


### PR DESCRIPTION
Otherwise it fails with `NameError: name 'glob' is not defined` when using `create_sra` method.