### PR TITLE
Indent line on dumping---include it in 'hint' block

### DIFF
--- a/docs/creation.rst
+++ b/docs/creation.rst
@@ -75,7 +75,7 @@ one Study section structured as defined by the
 `ISA-Tab Specification <http://isa-specs.readthedocs.io/en/latest/isatab.html>`_.
 
 .. hint:: Remember that when you ``dump()`` ISA content, you do it on the ``Investigation`` object. This means any
-``Study`` and ``Assay`` objects and content must be attached to the ``Investigation`` for it to be serialized out.
+   ``Study`` and ``Assay`` objects and content must be attached to the ``Investigation`` for it to be serialized out.
 
 Different classes in ``isatools.model.v1`` have class constructors and instance variables that roughly map to the
 ISA Abstract Model. For full details of how to instantiate model classes, access and manipulate ISA data as objects,


### PR DESCRIPTION
Small readability thing: second line of hint currently falls outside of the green box.
https://isatools.readthedocs.io/en/latest/creation.html

http://docutils.sourceforge.net/docs/ref/rst/directives.html#hint