### PR TITLE
Fix isa-tools.org address

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-<img align="left" src="http://www.isa-tools.org/wp-content/uploads/2016/03/isa-api-logo.png" width="150px">
+<img align="left" src="http://isa-tools.org/wp-content/uploads/2016/03/isa-api-logo.png" width="150px">
 <br>
 
 ----
-<img align="right" src="http://www.isa-tools.org/wp-content/themes/isatools-wp-theme/img/footer_logo.svg">
+<img align="right" src="http://isa-tools.org/wp-content/themes/isatools-wp-theme/img/footer_logo.svg">
 The open source ISA metadata tracking tools help to manage an increasingly diverse set of life science, environmental and biomedical experiments that employing one or a combination of technologies.
 
 Built around the ‘Investigation’ (the project context), Study’ (a unit of research) and ‘Assay’ (analytical measurement) general-purpose Tabular format, the ISA tools helps you to provide rich description of the experimental metadata (i.e. sample characteristics, technology and measurement types, sample-to-data relationships) so that the resulting data and discoveries are reproducible and reusable.
 
-To find out more about ISA, see [www.isa-tools.org](http://www.isa-tools.org)
+To find out more about ISA, see [isa-tools.org](http://isa-tools.org)
 
 To find out who's using ISA and about the ISA development and user community, see [www.isacommons.org](http://www.isacommons.org)
 
@@ -22,7 +22,7 @@ The *ISA API*  aims to provide you, the developer, with a set of tools to help y
 [![Documentation Status](https://readthedocs.org/projects/isatools/badge/?version=latest)](http://isatools.readthedocs.org/en/latest/?badge=latest)
 
 ----
-*Authors*: [The ISA team](http://www.isa-tools.org/team/).
+*Authors*: [The ISA team](http://isa-tools.org/team/).
 
 *License*:      This code is licensed under the [CPAL License](https://raw.githubusercontent.com/ISA-tools/isa-api/master/LICENSE.txt).
 


### PR DESCRIPTION
At time of writing http://www.isa-tools.org can not be resolved which causes broken links and missing images. This fixes that.