### PR TITLE
wrap a string in an Ontology Annotation

### DIFF
--- a/isatools/create/model.py
+++ b/isatools/create/model.py
@@ -1593,8 +1593,15 @@ class SampleAndAssayPlanDecoder(object):
 
     @staticmethod
     def loads_parameter_value(pv_dict):
-        return ParameterValue(category=ProtocolParameter(parameter_name=pv_dict["name"]), value=pv_dict["value"],
-                              unit=pv_dict.get('unit', None))
+        pv_name = pv_dict["name"]
+        return ParameterValue(
+            category=ProtocolParameter(
+                parameter_name=CharacteristicDecoder.loads_ontology_annotation(pv_name)
+                if isinstance(pv_name, dict) else pv_name
+            ),
+            value=pv_dict["value"],
+            unit=pv_dict.get('unit', None)
+        )
 
     @staticmethod
     def loads_protocol_type(pt_dict):

--- a/isatools/model.py
+++ b/isatools/model.py
@@ -2387,12 +2387,15 @@ class ProtocolParameter(Commentable):
 
     @parameter_name.setter
     def parameter_name(self, val):
-        if val is not None and not isinstance(val, (str, OntologyAnnotation)):
+        if val is None or isinstance(val, OntologyAnnotation):
+            self.__parameter_name = val
+        elif isinstance(val, str):
+            self.__parameter_name = OntologyAnnotation(term=val)
+        else:
             raise AttributeError(
                 'ProtocolParameter.parameter_name must be either a string or an OntologyAnnotation '
-                'or None; got {0}:{1}'.format(val, type(val)))
-        else:
-            self.__parameter_name = val
+                'or None; got {0}:{1}'.format(val, type(val))
+            )
 
     def __repr__(self):
         return 'isatools.model.ProtocolParameter(' \


### PR DESCRIPTION
This PR allows to pass strings to the `ProtocolParameter.name` property without breaking JSON serialisation. The string is silently wrapped into an `OntologyAnnotation`