### PR TITLE
Update isajson.py

### DIFF
--- a/isatools/isajson.py
+++ b/isatools/isajson.py
@@ -1730,6 +1730,7 @@ class ISAJSONEncoder(JSONEncoder):
                             "unit": {"@id": id_gen(x.unit)} if x.unit else None
                         }
                     ), obj.factor_values)),
+                    "derivesFrom": list(map(lambda x: {"@id": id_gen(x)}, obj.derives_from)) if obj.derives_from else [],
                     "comments": get_comments(obj.comments) if obj.comments else []
             })
 


### PR DESCRIPTION
fixes #420 

caused by omission of the "derivesFrom" attributes in the `get_sample(obj)` function in the `ISAJSONEncoder` class