### PR TITLE
Fix to determining JSON directory location.

### DIFF
--- a/isatools/convert/json2isatab.py
+++ b/isatools/convert/json2isatab.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import shutil
+import pathlib
 
 from isatools import isajson, isatab
 
@@ -50,7 +51,7 @@ def convert(json_fp, path, i_file_name='i_investigation.txt',
                 write_factor_values_in_assay_table=write_factor_values_in_assay_table)
     #  copy data files across from source directory where JSON is located
     log.info("Copying data files from source to target")
-    for file in [f for f in os.listdir(os.path.dirname(json_fp.name))
+    for file in [f for f in os.listdir(pathlib.Path(json_fp.name).resolve().parent)
                  if not (f.endswith('.txt') and (f.startswith('i_') or
                                                  f.startswith('s_') or
                                                  f.startswith('a_'))) and


### PR DESCRIPTION
If you run a program from the same directory that the JSON file is located in and use a relative path to create the file object, then the "name" property will only return the name of the file and you won't be able to parse the directory the file is in, which results in an error. I have changed the code to use the pathlib library to first resolve the file object name property into a full path and use the parent property to get the directory it is in.