### PR TITLE
Changed Tab and JSON validate

### DIFF
--- a/isatools/isajson/validate.py
+++ b/isatools/isajson/validate.py
@@ -808,14 +808,14 @@ default_isa_json_schemas_dir = os.path.join(
 def validate(
         fp,
         config_dir=default_config_dir,
-        log_level=None,
+        log_level=logging.INFO,
         base_schemas_dir="isa_model_version_1_0_schemas"
 ):
     if config_dir is None:
         config_dir = default_config_dir
-    if log_level in (
-            logging.NOTSET, logging.DEBUG, logging.INFO, logging.WARNING,
-            logging.ERROR, logging.CRITICAL):
+    if log_level is None:
+        log.disabled = True
+    else:
         log.setLevel(log_level)
     log.info("ISA JSON Validator from ISA tools API v0.12.")
     stream = StringIO()

--- a/isatools/isatab/validate/core.py
+++ b/isatools/isatab/validate/core.py
@@ -3,6 +3,7 @@ from typing import TextIO
 
 from os import path
 from glob import glob
+import logging
 
 from pandas.errors import ParserError
 
@@ -169,7 +170,7 @@ def validate(fp: TextIO,
              config_dir: str = default_config_dir,
              origin: str or None = None,
              rules: dict = None,
-             log_level=None) -> dict:
+             log_level: None|int = logging.INFO) -> dict:
     """
     A function to validate an ISA investigation tab file
     :param fp: the investigation file handler
@@ -179,8 +180,10 @@ def validate(fp: TextIO,
     :param log_level: optional log level (default: INFO)
     :return: a dictionary of the validation results (errors, warnings and info)
     """
-    if not log_level:
+    if log_level is None:
         log.disabled = True
+    else:
+        log.setLevel(log_level)
     message_handler.reset_store()
     validated = False
 


### PR DESCRIPTION
Normalized the log_level between the Tab and JSON validate functions, so they operate the same way.

Previously, there was no way to disable or silence logging in the JSON validate, and in the Tab validate there was no way to actually change the level. I changed it so both functions do the same thing in regards to log_level.