### PR TITLE
Added better messaging

### DIFF
--- a/isatools/isatab/validate/rules/rules_40xx.py
+++ b/isatools/isatab/validate/rules/rules_40xx.py
@@ -472,7 +472,7 @@ def load_table_checks(df, filename):
                         and not _RX_COMMENT.match(col):
                     spl = ("(E) Expected only Characteristics, "
                            "Factor Values or Comments following {} "
-                           "columns but found {} at offset {}".format(prop_name, col, x + 1, filename))
+                           "columns but found {} at offset {} in file {}".format(prop_name, col, x + 1, filename))
                     log.error(spl)
                     error = {
                         "message": "Unrecognised header",
@@ -489,7 +489,7 @@ def load_table_checks(df, filename):
                         and not _RX_PARAMETER_VALUE.match(col) \
                         and not _RX_COMMENT.match(col):
                     spl = ("(E) Unexpected column heading following {} "
-                           "column. Found {} at offset {}".format(prop_name, col, x + 1, filename))
+                           "column. Found {} at offset {} in file {}".format(prop_name, col, x + 1, filename))
                     log.error(spl)
                     error = {
                         "message": "Unrecognised header",
@@ -532,7 +532,7 @@ def load_table_checks(df, filename):
                                        'Term Accession Number']:
                             spl = ("(E) Unexpected column heading "
                                    "following {} column. Found {} at "
-                                   "offset {}".format(prop_name, col, x + 1, filename))
+                                   "offset {} in file {}".format(prop_name, col, x + 1, filename))
                             log.error(spl)
                             error = {
                                 "message": "Unrecognised header",
@@ -594,9 +594,8 @@ def load_table_checks(df, filename):
         elif _RX_FACTOR_VALUE.match(prop_name):
             for x, col in enumerate(object_columns[2:]):
                 if col not in ['Term Source REF', 'Term Accession Number']:
-                    spl = (
-                        "(E) Unexpected column heading following {} column. "
-                        "Found {} at offset {}".format(prop_name, col, x + 1, filename))
+                    spl = ("(E) Unexpected column heading following {} column. "
+                           "Found {} at offset {} in file {}".format(prop_name, col, x + 1, filename))
                     log.error(spl)
                     error = {
                         "message": "Unrecognised header",

--- a/isatools/isatab/validate/rules/rules_40xx.py
+++ b/isatools/isatab/validate/rules/rules_40xx.py
@@ -504,7 +504,7 @@ def load_table_checks(df, filename):
                         and not _RX_COMMENT.match(col):
                     spl = ("(E) Expected only Characteristics, "
                            "Comments following {} "
-                           "columns but found {} at offset {}".format(prop_name, col, x + 1, filename))
+                           "columns but found {} at offset {} in file {}".format(prop_name, col, x + 1, filename))
                     log.error(spl)
                     error = {
                         "message": "Unrecognised header",
@@ -512,18 +512,6 @@ def load_table_checks(df, filename):
                         "code": 4014
                     }
                     validator.add_error(**error)
-            # if len(object_columns) > 1:
-            #
-            #     spl = ("Unexpected column heading(s) following {} column. "
-            #            "Found {} at offset {}".format(
-            #             prop_name, object_columns[1:], 2), filename)
-            #     log.error(spl)
-            #     error = {
-            #         "message": "Unrecognised header",
-            #         "supplemental": spl,
-            #         "code": 4014
-            #     }
-            #     validator.add_error(**error)
         elif prop_name == 'Labeled Extract Name':
             if len(object_columns) > 1:
                 if object_columns[1] == 'Label':
@@ -548,7 +536,7 @@ def load_table_checks(df, filename):
                                 and not _RX_COMMENT.match(col):
                             spl = ("(E) Expected only Characteristics, "
                                    "Comments following {} "
-                                   "columns but found {} at offset {}".format(prop_name, col, x + 1, filename))
+                                   "columns but found {} at offset {} in file {}".format(prop_name, col, x + 1, filename))
                             log.error(spl)
                             error = {
                                 "message": "Unrecognised header",
@@ -558,7 +546,7 @@ def load_table_checks(df, filename):
                             validator.add_error(**error)
             else:
                 spl = ("Expected Label column after Labeled Extract Name "
-                       "but none found")
+                       "but none found in file {}".format(filename))
                 log.error(spl)
                 error = {
                     "message": "Unrecognised header",
@@ -567,23 +555,10 @@ def load_table_checks(df, filename):
                 }
                 validator.add_error(**error)
         elif prop_name in DATA_FILE_LABELS:
-            # [
-            #     'Raw Data File',
-            #     'Raw Spectral Data File',
-            #     'Free Induction Decay Data File',
-            #     'Image File',
-            #     'Derived Data File',
-            #     'Derived Spectral Data File',
-            #     'Derived Array Data File',
-            #     'Array Data File',
-            #     'Protein Assignment File',
-            #     'Peptide Assignment File',
-            #     'Post Translational Modification Assignment File'
-            # ]
             for x, col in enumerate(object_columns[1:]):
                 if not _RX_COMMENT.match(col):
                     spl = ("(E) Expected only Comments following {} "
-                           "columns but found {} at offset {}".format(prop_name, col, x + 1, filename))
+                           "columns but found {} at offset {} in file {}".format(prop_name, col, x + 1, filename))
                     log.error(spl)
                     error = {
                         "message": "Unrecognised header",


### PR DESCRIPTION
For some reason the bottom part of the function only logged errors and did not add them to the validator dictionary. They also did not indicate which filename the error was from, so tracking down where the problem is was difficult. This might just be an oversight since the warnings at the top of the function were just fine.

I would also like to bring up an issue with this function. It doesn't seem to be working quite correctly. I have attached an assay from the examples that this function prints errors for. The first error is "(E) Unexpected column heading following Labeled Extract Name column. Found MS Assay Name at offset 3" If I am understanding the code correctly it is trying to make sure that "Labeled Extract Name" is followed by "Label" and then possibly "Term Source REF" and/or "Term Accession Number". The "Labeled Extract Name" column in this file is followed by those columns exactly, but after those "MS Assay Name" is next. I think the issue is where "object_index" is created. It doesn't create a new set of object columns on the "MS Assay Name" column, so that column and the 2 comments that follow it are put into the "Labeled Extract Name" object columns. I think this happens for other columns in the file as well. It looks to me like this function might have been made originally when there were fewer column headers and was then updated at some point, but parts were missed in the update. Someone who understands the possible column headers should probably take a look at what is going on here.

[a_proteome.txt](https://github.com/ISA-tools/isa-api/files/14117871/a_proteome.txt)
