### PR TITLE
Changed messaging on study assays errors

### DIFF
--- a/isatools/isatab/validate/rules/rules_30xx.py
+++ b/isatools/isatab/validate/rules/rules_30xx.py
@@ -19,7 +19,7 @@ def check_filenames_present(i_df_dict: dict) -> None:
             if filename == '':
                 spl = "STUDY.{}, STUDY ASSAY.{}".format(s_pos, a_pos)
                 validator.add_warning.append(message="Missing assay file name", supplemental=spl, code=3005)
-                log.warning("(W) An assay filename is missing for STUDY ASSAY.{}".format(a_pos))
+                log.warning("(W) An assay filename is missing for STUDY.{}, STUDY ASSAY.{}".format(s_pos, a_pos))
 
 
 def check_date_formats(i_df_dict):

--- a/isatools/isatab/validate/rules/rules_40xx.py
+++ b/isatools/isatab/validate/rules/rules_40xx.py
@@ -107,10 +107,10 @@ def check_measurement_technology_types(i_df_dict, configs):
                 lowered_mt = measurement_types[x].lower()
                 lowered_tt = technology_types[x].lower()
                 if (lowered_mt, lowered_tt) not in configs.keys():
-                    spl = "Measurement {}/technology {}, STUDY ASSAY.{}"
-                    spl = spl.format(measurement_types[x], technology_types[x], i)
+                    spl = "Measurement {}/technology {}, STUDY.{}, STUDY ASSAY.{}"
+                    spl = spl.format(measurement_types[x], technology_types[x], i, x)
                     error = ("(E) Could not load configuration for measurement type '{}' and technology type '{}' "
-                             "for STUDY ASSAY.{}'").format(measurement_types[x], technology_types[x], i)
+                             "for STUDY.{}, STUDY ASSAY.{}'").format(measurement_types[x], technology_types[x], i, x)
                     validator.add_error(message="Measurement/technology type invalid", supplemental=spl, code=4002)
                     log.error(error)
 


### PR DESCRIPTION
The messaging on the 2 checks dealing with study assays did not make it clear exactly which assay and which study had the issue. I changed the messaging so it clearly indicates the affected study and assay.