### PR TITLE
Validate config changes

### DIFF
--- a/isatools/isatab/validate/core.py
+++ b/isatools/isatab/validate/core.py
@@ -169,7 +169,8 @@ def validate(fp: TextIO,
              config_dir: str = default_config_dir,
              origin: str or None = None,
              rules: dict = None,
-             log_level=None) -> dict:
+             log_level=None,
+             no_config: bool = False) -> dict:
     """
     A function to validate an ISA investigation tab file
     :param fp: the investigation file handler
@@ -177,6 +178,7 @@ def validate(fp: TextIO,
     :param origin: value accepted = mzml2isa or None
     :param rules: optional rules to run (default: all rules)
     :param log_level: optional log level (default: INFO)
+    :param no_config: whether or not to validate against configs (default: False)
     :return: a dictionary of the validation results (errors, warnings and info)
     """
     if not log_level:
@@ -191,6 +193,7 @@ def validate(fp: TextIO,
             "investigation_df_dict": i_df_dict,
             "dir_context": path.dirname(fp.name),
             "configs": config_dir,
+            "no_config": no_config
         }
         investigation_validator = ISAInvestigationValidator(**params, **built_rules['investigation'])
 

--- a/isatools/isatab/validate/rules/core.py
+++ b/isatools/isatab/validate/rules/core.py
@@ -5,6 +5,7 @@ from os import path
 
 from pandas import DataFrame
 
+from isatools.io import isatab_configurator
 from isatools.utils import utf8_text_file_open
 from isatools.isatab.defaults import NUMBER_OF_STUDY_GROUPS
 from isatools.isatab.load import load_table
@@ -155,7 +156,8 @@ class ISAStudyValidator:
         self.params = {
             **validator.params,
             'study_df': study_df,
-            'config': validator.params['configs'][('[sample]', '')],
+            'config': validator.params['configs'][('[sample]', '')] if ('[sample]', '') in validator.params['configs'] 
+                                                                    else isatab_configurator.IsaTabConfigFileType(),
             'study_filename': study_filename
         }
         with utf8_text_file_open(path.join(self.params['dir_context'], study_filename)) as s_fp:
@@ -207,7 +209,7 @@ class ISAAssayValidator:
         if assay_filename != '':
             lowered_mt = assay_df['Study Assay Measurement Type'].tolist()[assay_index].lower()
             lowered_tt = assay_df['Study Assay Technology Type'].tolist()[assay_index].lower()
-            self.params['config'] = self.params['configs'].get((lowered_mt, lowered_tt), None)
+            self.params['config'] = self.params['configs'].get((lowered_mt, lowered_tt), isatab_configurator.IsaTabConfigFileType())
             if self.params['config']:
                 with utf8_text_file_open(path.join(self.params['dir_context'], assay_filename)) as a_fp:
                     self.params['assay_table'] = load_table(a_fp)

--- a/isatools/isatab/validate/rules/core.py
+++ b/isatools/isatab/validate/rules/core.py
@@ -113,7 +113,8 @@ class ISAInvestigationValidator:
                  dir_context: str,
                  configs: str,
                  available_rules: list = INVESTIGATION_RULES_MAPPING,
-                 rules_to_run: tuple = DEFAULT_INVESTIGATION_RULES):
+                 rules_to_run: tuple = DEFAULT_INVESTIGATION_RULES,
+                 no_config: bool = False):
         """ The ISA investigation validator class
 
         :param investigation_df_dict: a dictionary of DataFrames and lists of DataFrames representing the investigation file
@@ -121,6 +122,7 @@ class ISAInvestigationValidator:
         :param configs: directory of the XML config files
         :param available_rules: a customizable list of all available rules for investigation objects
         :param rules_to_run: a customizable tuple of rules identifiers to run for investigation objects
+        :param no_config: whether or not to validate against configs (default: False)
         """
         self.all_rules = Rules(rules_to_run=rules_to_run, available_rules=available_rules)
         self.has_validated = False
@@ -128,7 +130,8 @@ class ISAInvestigationValidator:
             'investigation_df_dict': investigation_df_dict,
             'dir_context': dir_context,
             'configs': configs,
-            'term_source_refs': None
+            'term_source_refs': None,
+            "no_config": no_config
         }
         self.all_rules.validate_rules(validator=self)
 
@@ -141,7 +144,8 @@ class ISAStudyValidator:
                  study_filename: str,
                  study_df: DataFrame,
                  available_rules: List = STUDY_RULES_MAPPING,
-                 rules_to_run: tuple = DEFAULT_STUDY_RULES):
+                 rules_to_run: tuple = DEFAULT_STUDY_RULES,
+                 no_config: bool = False):
         """
         The ISA study validator class
         :param validator: the investigation validator
@@ -150,6 +154,7 @@ class ISAStudyValidator:
         :param study_df: the study dataframe
         :param available_rules: a customizable list of all available rules for investigation objects
         :param rules_to_run: a customizable tuple of rules identifiers to run for investigation objects
+        :param no_config: whether or not to validate against configs (default: False)
         """
         self.all_rules = Rules(rules_to_run=rules_to_run, available_rules=available_rules)
         self.has_validated = False
@@ -185,7 +190,8 @@ class ISAAssayValidator:
                  assay_filename: str = None,
                  assay_df: DataFrame = None,
                  available_rules: List = ASSAY_RULES_MAPPING,
-                 rules_to_run: tuple = DEFAULT_ASSAY_RULES):
+                 rules_to_run: tuple = DEFAULT_ASSAY_RULES,
+                 no_config: bool = False):
         """
         The ISA assay validator class
         :param assay_tables: list of assay tables
@@ -195,6 +201,7 @@ class ISAAssayValidator:
         :param assay_df: the assay dataframe
         :param available_rules: a customizable list of all available rules for investigation objects
         :param rules_to_run: a customizable tuple of rules identifiers to run for investigation objects
+        :param no_config: whether or not to validate against configs (default: False)
         """
         self.all_rules = Rules(rules_to_run=rules_to_run, available_rules=available_rules)
         self.has_validated = False

--- a/isatools/isatab/validate/rules/defaults.py
+++ b/isatools/isatab/validate/rules/defaults.py
@@ -45,9 +45,9 @@ INVESTIGATION_RULES_MAPPING = [
     {'rule': check_pubmed_ids_format, 'params': ['investigation_df_dict'], 'identifier': '3003'},
     {'rule': check_ontology_sources, 'params': ['investigation_df_dict'], 'identifier': '3008'},
 
-    {'rule': load_config, 'params': ['configs'], 'identifier': '4001'},
-    {'rule': check_measurement_technology_types, 'params': ['investigation_df_dict', 'configs'], 'identifier': '4002'},
-    {'rule': check_investigation_against_config, 'params': ['investigation_df_dict', 'configs'], 'identifier': '4003'},
+    {'rule': load_config, 'params': ['configs', 'no_config'], 'identifier': '4001'},
+    {'rule': check_measurement_technology_types, 'params': ['investigation_df_dict', 'configs', 'no_config'], 'identifier': '4002'},
+    {'rule': check_investigation_against_config, 'params': ['investigation_df_dict', 'configs', 'no_config'], 'identifier': '4003'},
 
     # copies
     {'rule': check_table_files_read, 'params': ['investigation_df_dict', 'dir_context'], 'identifier': '0008'},

--- a/isatools/isatab/validate/rules/defaults.py
+++ b/isatools/isatab/validate/rules/defaults.py
@@ -58,22 +58,22 @@ INVESTIGATION_RULES_MAPPING = [
 
 STUDY_RULES_MAPPING = [
 
-    {'rule': check_unit_field, 'params': ['study_sample_table', 'config'], 'identifier': '1099'},
+    {'rule': check_unit_field, 'params': ['study_sample_table', 'config', 'no_config'], 'identifier': '1099'},
 
     {
         'rule': check_ontology_fields,
-        'params': ['study_sample_table', 'config', 'term_source_refs'],
+        'params': ['study_sample_table', 'config', 'term_source_refs', 'no_config'],
         'identifier': '3010'
     },
 
-    {'rule': check_required_fields, 'params': ['study_sample_table', 'config'], 'identifier': '4003'},
+    {'rule': check_required_fields, 'params': ['study_sample_table', 'config', 'no_config'], 'identifier': '4003'},
     {'rule': check_factor_value_presence, 'params': ['study_sample_table'], 'identifier': '4007'},
     {
         'rule': check_protocol_fields,
-        'params': ['study_sample_table', 'config', 'protocol_names_and_types'],
+        'params': ['study_sample_table', 'config', 'protocol_names_and_types', 'no_config'],
         'identifier': '4009'
     },
-    {'rule': check_field_values, 'params': ['study_sample_table', 'config'], 'identifier': '4011'},
+    {'rule': check_field_values, 'params': ['study_sample_table', 'config', 'no_config'], 'identifier': '4011'},
     {'rule': load_table_checks, 'params': ['study_sample_table', 'study_filename'], 'identifier': '4014'},
 
     {
@@ -83,30 +83,30 @@ STUDY_RULES_MAPPING = [
     },
 
     # copies
-    {'rule': check_required_fields, 'params': ['study_sample_table', 'config'], 'identifier': '4008'},
-    {'rule': check_required_fields, 'params': ['study_sample_table', 'config'], 'identifier': '4010'},
+    {'rule': check_required_fields, 'params': ['study_sample_table', 'config', 'no_config'], 'identifier': '4008'},
+    {'rule': check_required_fields, 'params': ['study_sample_table', 'config', 'no_config'], 'identifier': '4010'},
 ]
 
 ASSAY_RULES_MAPPING = [
     {'rule': check_sample_names, 'params': ['study_sample_table', 'assay_tables'], 'identifier': '0000'},
 
-    {'rule': check_unit_field, 'params': ['assay_table', 'config'], 'identifier': '1099'},
+    {'rule': check_unit_field, 'params': ['assay_table', 'config', 'no_config'], 'identifier': '1099'},
 
-    {'rule': check_ontology_fields, 'params': ['assay_table', 'config', 'term_source_refs'], 'identifier': '3010'},
+    {'rule': check_ontology_fields, 'params': ['assay_table', 'config', 'term_source_refs', 'no_config'], 'identifier': '3010'},
 
-    {'rule': check_required_fields, 'params': ['assay_table', 'config'], 'identifier': '4003'},
+    {'rule': check_required_fields, 'params': ['assay_table', 'config', 'no_config'], 'identifier': '4003'},
     {'rule': check_factor_value_presence, 'params': ['assay_table'], 'identifier': '4007'},
     {
         'rule': check_protocol_fields,
-        'params': ['assay_table', 'config', 'protocol_names_and_types'],
+        'params': ['assay_table', 'config', 'protocol_names_and_types', 'no_config'],
         'identifier': '4009'
     },
-    {'rule': check_field_values, 'params': ['assay_table', 'config'], 'identifier': '4011'},
+    {'rule': check_field_values, 'params': ['assay_table', 'config', 'no_config'], 'identifier': '4011'},
     {'rule': load_table_checks, 'params': ['assay_table', 'assay_filename'], 'identifier': '4014'},
 
     # copies
-    {'rule': check_required_fields, 'params': ['study_sample_table', 'config'], 'identifier': '4008'},
-    {'rule': check_required_fields, 'params': ['study_sample_table', 'config'], 'identifier': '4010'},
+    {'rule': check_required_fields, 'params': ['study_sample_table', 'config', 'no_config'], 'identifier': '4008'},
+    {'rule': check_required_fields, 'params': ['study_sample_table', 'config', 'no_config'], 'identifier': '4010'},
 
     {
         'rule': check_study_groups,

--- a/isatools/isatab/validate/rules/rules_10xx.py
+++ b/isatools/isatab/validate/rules/rules_10xx.py
@@ -342,26 +342,27 @@ def check_unit_field(table, cfg):
 
     result = True
     for icol, header in enumerate(table.columns):
-        cfields = [i for i in cfg.get_isatab_configuration()[0].get_field() if i.header == header]
-        if len(cfields) != 1:
-            continue
-        cfield = cfields[0]
-        ucfields = [i for i in cfg.get_isatab_configuration()[0].get_unit_field() if i.pos == cfield.pos + 1]
-        if len(ucfields) != 1:
-            continue
-        ucfield = ucfields[0]
-        if ucfield.is_required:
-            rheader = None
-            rindx = icol + 1
-            if rindx < len(table.columns):
-                rheader = table.columns[rindx]
-            if rheader is None or rheader.lower() != 'unit':
-                spl = "The field '{}' in the file '{}' misses a required 'Unit' column".format(header, table.filename)
-                validator.add_warning(message="Cell requires a Unit", supplemental=spl, code=4999)
-                log.warning("(W) {}".format(spl))
-                result = False
-            else:
-                for irow in range(len(table.index)):
-                    check = check_unit_value(table.iloc[irow][icol], table.iloc[irow][rindx], cfield, table.filename)
-                    result = result and check
+        if cfg.get_isatab_configuration():
+            cfields = [i for i in cfg.get_isatab_configuration()[0].get_field() if i.header == header]
+            if len(cfields) != 1:
+                continue
+            cfield = cfields[0]
+            ucfields = [i for i in cfg.get_isatab_configuration()[0].get_unit_field() if i.pos == cfield.pos + 1]
+            if len(ucfields) != 1:
+                continue
+            ucfield = ucfields[0]
+            if ucfield.is_required:
+                rheader = None
+                rindx = icol + 1
+                if rindx < len(table.columns):
+                    rheader = table.columns[rindx]
+                if rheader is None or rheader.lower() != 'unit':
+                    spl = "The field '{}' in the file '{}' misses a required 'Unit' column".format(header, table.filename)
+                    validator.add_warning(message="Cell requires a Unit", supplemental=spl, code=4999)
+                    log.warning("(W) {}".format(spl))
+                    result = False
+                else:
+                    for irow in range(len(table.index)):
+                        check = check_unit_value(table.iloc[irow][icol], table.iloc[irow][rindx], cfield, table.filename)
+                        result = result and check
     return result

--- a/isatools/isatab/validate/rules/rules_10xx.py
+++ b/isatools/isatab/validate/rules/rules_10xx.py
@@ -315,11 +315,12 @@ def check_study_factor_names(i_df_dict):
                 log.warning(warning)
 
 
-def check_unit_field(table, cfg):
+def check_unit_field(table, cfg, no_config):
     """Checks if unit columns are valid against a configuration
 
     :param table: Table DataFrame
     :param cfg: An ISA Configuration object
+    :param no_config: whether or not to validate against configs
     :return: True if all unit columns in table are OK, False if not OK
     """
 
@@ -340,9 +341,8 @@ def check_unit_field(table, cfg):
             return False
         return True
 
-    result = True
-    for icol, header in enumerate(table.columns):
-        if cfg.get_isatab_configuration():
+    if cfg.get_isatab_configuration() and not no_config:
+        for icol, header in enumerate(table.columns):
             cfields = [i for i in cfg.get_isatab_configuration()[0].get_field() if i.header == header]
             if len(cfields) != 1:
                 continue
@@ -360,9 +360,6 @@ def check_unit_field(table, cfg):
                     spl = "The field '{}' in the file '{}' misses a required 'Unit' column".format(header, table.filename)
                     validator.add_warning(message="Cell requires a Unit", supplemental=spl, code=4999)
                     log.warning("(W) {}".format(spl))
-                    result = False
                 else:
                     for irow in range(len(table.index)):
-                        check = check_unit_value(table.iloc[irow][icol], table.iloc[irow][rindx], cfield, table.filename)
-                        result = result and check
-    return result
+                        check_unit_value(table.iloc[irow][icol], table.iloc[irow][rindx], cfield, table.filename)

--- a/isatools/isatab/validate/rules/rules_30xx.py
+++ b/isatools/isatab/validate/rules/rules_30xx.py
@@ -188,13 +188,12 @@ def check_ontology_fields(table, cfg, tsrs, no_config):
             if 'term source ref' not in rheader.lower() or 'term accession number' not in rrheader.lower():
                 warning = "(W) The Field '{}' should have values from ontologies and has no ontology headers instead"
                 log.warning(warning.format(header))
-                result = False
                 continue
     
             for irow in range(len(table.index)):
-                result = result and check_single_field(table.iloc[irow][icol],
-                                                       table.iloc[irow][rindx],
-                                                       table.iloc[irow][rrindx],
-                                                       cfield,
-                                                       table.filename)
+                check_single_field(table.iloc[irow][icol],
+                                   table.iloc[irow][rindx],
+                                   table.iloc[irow][rrindx],
+                                   cfield,
+                                   table.filename)
 

--- a/isatools/isatab/validate/rules/rules_30xx.py
+++ b/isatools/isatab/validate/rules/rules_30xx.py
@@ -128,13 +128,14 @@ def check_ontology_sources(i_df_dict):
     return term_source_refs
 
 
-def check_ontology_fields(table, cfg, tsrs):
+def check_ontology_fields(table, cfg, tsrs, no_config):
     """ Checks ontology annotation columns are correct for a given configuration
     in a table
 
     :param table: Table DataFrame
     :param cfg: An ISA Configuration object
     :param tsrs: List of Term Source References from the Ontology Source
+    :param no_config: whether or not to validate against configs
     Reference section
     :return: True if OK, False if not OK
     """
@@ -167,10 +168,9 @@ def check_ontology_fields(table, cfg, tsrs):
             return_value = False
         return return_value
 
-    result = True
-    nfields = len(table.columns)
-    for icol, header in enumerate(table.columns):
-        if cfg.get_isatab_configuration():
+    if cfg.get_isatab_configuration() and not no_config:
+        nfields = len(table.columns)
+        for icol, header in enumerate(table.columns):
             cfields = [i for i in cfg.get_isatab_configuration()[0].get_field() if i.header == header]
             if len(cfields) != 1:
                 continue
@@ -198,4 +198,3 @@ def check_ontology_fields(table, cfg, tsrs):
                                                        cfield,
                                                        table.filename)
 
-    return result

--- a/isatools/isatab/validate/rules/rules_30xx.py
+++ b/isatools/isatab/validate/rules/rules_30xx.py
@@ -170,31 +170,32 @@ def check_ontology_fields(table, cfg, tsrs):
     result = True
     nfields = len(table.columns)
     for icol, header in enumerate(table.columns):
-        cfields = [i for i in cfg.get_isatab_configuration()[0].get_field() if i.header == header]
-        if len(cfields) != 1:
-            continue
-        cfield = cfields[0]
-        if cfield.get_recommended_ontologies() is None:
-            continue
-        rindx = icol + 1
-        rrindx = icol + 2
-        rheader = ''
-        rrheader = ''
-        if rindx < nfields:
-            rheader = table.columns[rindx]
-        if rrindx < nfields:
-            rrheader = table.columns[rrindx]
-        if 'term source ref' not in rheader.lower() or 'term accession number' not in rrheader.lower():
-            warning = "(W) The Field '{}' should have values from ontologies and has no ontology headers instead"
-            log.warning(warning.format(header))
-            result = False
-            continue
-
-        for irow in range(len(table.index)):
-            result = result and check_single_field(table.iloc[irow][icol],
-                                                   table.iloc[irow][rindx],
-                                                   table.iloc[irow][rrindx],
-                                                   cfield,
-                                                   table.filename)
+        if cfg.get_isatab_configuration():
+            cfields = [i for i in cfg.get_isatab_configuration()[0].get_field() if i.header == header]
+            if len(cfields) != 1:
+                continue
+            cfield = cfields[0]
+            if cfield.get_recommended_ontologies() is None:
+                continue
+            rindx = icol + 1
+            rrindx = icol + 2
+            rheader = ''
+            rrheader = ''
+            if rindx < nfields:
+                rheader = table.columns[rindx]
+            if rrindx < nfields:
+                rrheader = table.columns[rrindx]
+            if 'term source ref' not in rheader.lower() or 'term accession number' not in rrheader.lower():
+                warning = "(W) The Field '{}' should have values from ontologies and has no ontology headers instead"
+                log.warning(warning.format(header))
+                result = False
+                continue
+    
+            for irow in range(len(table.index)):
+                result = result and check_single_field(table.iloc[irow][icol],
+                                                       table.iloc[irow][rindx],
+                                                       table.iloc[irow][rrindx],
+                                                       cfield,
+                                                       table.filename)
 
     return result

--- a/isatools/isatab/validate/rules/rules_40xx.py
+++ b/isatools/isatab/validate/rules/rules_40xx.py
@@ -13,7 +13,7 @@ from isatools.isatab.defaults import (
 )
 
 
-def check_investigation_against_config(i_df, configs, no_config):
+def check_investigation_against_config(i_df_dict, configs, no_config):
     """Checks investigation file against the loaded configurations
 
     :param i_df_dict: A dictionary of DataFrames and lists of DataFrames representing the investigation file
@@ -54,18 +54,18 @@ def check_investigation_against_config(i_df, configs, no_config):
     if ('[investigation]', '') in configs and not no_config:
         config_fields = configs[('[investigation]', '')].get_isatab_configuration()[0].get_field()
         required_fields = [i.header for i in config_fields if i.is_required]
-        check_section_against_required_fields_one_value(i_df['investigation'], required_fields)
-        check_section_against_required_fields_one_value(i_df['i_publications'], required_fields)
-        check_section_against_required_fields_one_value(i_df['i_contacts'], required_fields)
+        check_section_against_required_fields_one_value(i_df_dict['investigation'], required_fields)
+        check_section_against_required_fields_one_value(i_df_dict['i_publications'], required_fields)
+        check_section_against_required_fields_one_value(i_df_dict['i_contacts'], required_fields)
 
-        for x, study_df in enumerate(i_df['studies']):
-            check_section_against_required_fields_one_value(i_df['studies'][x], required_fields, x)
-            check_section_against_required_fields_one_value(i_df['s_design_descriptors'][x], required_fields, x)
-            check_section_against_required_fields_one_value(i_df['s_publications'][x], required_fields, x)
-            check_section_against_required_fields_one_value(i_df['s_factors'][x], required_fields, x)
-            check_section_against_required_fields_one_value(i_df['s_assays'][x], required_fields, x)
-            check_section_against_required_fields_one_value(i_df['s_protocols'][x], required_fields, x)
-            check_section_against_required_fields_one_value(i_df['s_contacts'][x], required_fields, x)
+        for x, study_df in enumerate(i_df_dict['studies']):
+            check_section_against_required_fields_one_value(i_df_dict['studies'][x], required_fields, x)
+            check_section_against_required_fields_one_value(i_df_dict['s_design_descriptors'][x], required_fields, x)
+            check_section_against_required_fields_one_value(i_df_dict['s_publications'][x], required_fields, x)
+            check_section_against_required_fields_one_value(i_df_dict['s_factors'][x], required_fields, x)
+            check_section_against_required_fields_one_value(i_df_dict['s_assays'][x], required_fields, x)
+            check_section_against_required_fields_one_value(i_df_dict['s_protocols'][x], required_fields, x)
+            check_section_against_required_fields_one_value(i_df_dict['s_contacts'][x], required_fields, x)
 
 
 def load_config(config_dir, no_config):
@@ -96,7 +96,7 @@ def load_config(config_dir, no_config):
     return configs
 
 
-def check_measurement_technology_types(i_df, configs, no_config):
+def check_measurement_technology_types(i_df_dict, configs, no_config):
     """Rule 4002
 
     :param i_df_dict: A dictionary of DataFrames and lists of DataFrames representing the investigation file
@@ -107,7 +107,7 @@ def check_measurement_technology_types(i_df, configs, no_config):
     if no_config:
         return
 
-    for i, assay_df in enumerate(i_df['s_assays']):
+    for i, assay_df in enumerate(i_df_dict['s_assays']):
         measurement_types = assay_df['Study Assay Measurement Type'].tolist()
         technology_types = assay_df['Study Assay Technology Type'].tolist()
         if len(measurement_types) == len(technology_types):
@@ -232,12 +232,12 @@ def check_field_values(table, cfg, no_config):
             return False
         if not is_valid_value:
             msg = "A value does not correspond to the correct data type"
-            spl = "Invalid value '{}' for type '{}' of the field '{}'"
-            spl = spl.format(cell_value, data_type, cfg_field.header)
+            spl = "Invalid value '{}' for type '{}' of the field '{}' in the file '{}'"
+            spl = spl.format(cell_value, data_type, cfg_field.header, table.filename)
+            if data_type == 'list':
+                spl = spl + ". Value must be one of: " + cfg_field.list_values
             validator.add_warning(message=msg, supplemental=spl, code=4011)
             log.warning("(W) {}".format(spl))
-            if data_type == 'list':
-                log.warning("(W) Value must be one of: " + cfg_field.list_values)
         return is_valid_value
 
     if cfg.get_isatab_configuration() and not no_config:

--- a/tests/isatab/validate/test_core.py
+++ b/tests/isatab/validate/test_core.py
@@ -17,7 +17,7 @@ class TestValidators(unittest.TestCase):
         data_path = path.join(path.dirname(path.abspath(__file__)), '..', '..', 'data', 'tab', 'BII-S-3')
         with open(path.join(data_path, 'i_gilbert.txt'), 'r') as data_file:
             r = validate(fp=data_file, config_dir=self.default_conf, origin="")
-        self.assertEqual(len(r['warnings']), 10)
+        self.assertEqual(len(r['warnings']), 21)
 
     def test_mtbls267(self):
         data_path = path.join(path.dirname(path.abspath(__file__)), '..', '..', 'data', 'tab', 'MTBLS267-partial')
@@ -42,7 +42,7 @@ class TestValidators(unittest.TestCase):
         data_path = path.join(path.dirname(path.abspath(__file__)), '..', '..', 'data', 'tab', 'BII-S-7')
         with open(path.join(data_path, 'i_matteo.txt'), 'r') as data_file:
             report = validate(fp=data_file, config_dir=self.default_conf)
-        self.assertEqual(len(report['warnings']), 14)
+        self.assertEqual(len(report['warnings']), 42)
 
     def test_print_rule(self):
         raw_rule = INVESTIGATION_RULES_MAPPING[0]
@@ -82,7 +82,7 @@ class TestValidators(unittest.TestCase):
         data_path = path.join(path.dirname(path.abspath(__file__)), '..', '..', 'data', 'tab', 'BII-S-3')
         with open(path.join(data_path, 'i_gilbert.txt'), 'r') as data_file:
             r = validate(data_file, rules=rules)
-        self.assertEqual(len(r['warnings']), 10)
+        self.assertEqual(len(r['warnings']), 21)
 
         rule = '12000'
         expected_error = {


### PR DESCRIPTION
This PR goes all the way back to the initial meeting we had to discuss adding a way to opt out of the configuration validations. I have implemented that here. A "no_config" parameter was added to both the JSON and Tab validation and propagated appropriately so configuration validation can be optional. There are also a few messaging changes and some slight fixes.

One issue I found during testing was that some of the rules in the Tab validate have lines like `result = result and func()`. This essentially makes it to where the func() won't run after 1 error or warning is found. This eliminates some warnings or errors from being repeated multiple times, but also hides when there are multiple different ones at the same time.  "test_b_ii_s_3" in "isatab/validate/test_core.py" is a good example. There are 2 different columns with warnings, but before this change you only saw 1 of those warnings, but those 2 warnings are repeated for each row. I'm not sure what would be the preference for how to handle this. I thought that maybe before issuing the warning there could be a check to see if the exact same warning was already issued and not do it again, but implementing this in a robust way did not seem trivial. For now, I simply left it so that the warnings/errors are repeated and changed the tests to match that where necessary.