### PR TITLE
Protocol types refactor

### DIFF
--- a/isatools/constants.py
+++ b/isatools/constants.py
@@ -1,4 +1,5 @@
 SYNONYMS = 'synonyms'
+HEADER = 'header'
 
 MATERIAL_LABELS = [
     'Source Name',

--- a/isatools/isatab/dump/write.py
+++ b/isatools/isatab/dump/write.py
@@ -240,7 +240,13 @@ def write_assay_table_files(inv_obj, output_dir, write_factor_values=False):
 
     if not isinstance(inv_obj, Investigation):
         raise NotImplementedError
-    protocol_types_dict = load_protocol_types_info()
+    yaml_dict = load_protocol_types_info()
+    protocol_types_dict = {}
+    for protocol, attributes in yaml_dict.items():
+        protocol_types_dict[protocol] = attributes
+        for synonym in attributes[SYNONYMS]:
+            protocol_types_dict[synonym] = attributes
+    
     for study_obj in inv_obj.studies:
         for assay_obj in study_obj.assays:
             a_graph = assay_obj.graph
@@ -300,7 +306,8 @@ def write_assay_table_files(inv_obj, output_dir, write_factor_values=False):
                         else:
                             protocol_type = node.executes_protocol.protocol_type.lower()
                         
-                        if protocol_type in protocol_types_dict:
+                        if protocol_type in protocol_types_dict and\
+                            protocol_types_dict[protocol_type][HEADER]:
                             oname_label = protocol_types_dict[protocol_type][HEADER]
                         else:
                             oname_label = None
@@ -360,7 +367,8 @@ def write_assay_table_files(inv_obj, output_dir, write_factor_values=False):
                             else:
                                 protocol_type = node.executes_protocol.protocol_type.lower()
                             
-                            if protocol_type in protocol_types_dict:
+                            if protocol_type in protocol_types_dict and\
+                                protocol_types_dict[protocol_type][HEADER]:
                                 oname_label = protocol_types_dict[protocol_type][HEADER]
                             else:
                                 oname_label = None

--- a/isatools/isatab/utils.py
+++ b/isatools/isatab/utils.py
@@ -515,30 +515,30 @@ def get_object_column_map(isatab_header, df_columns):
     return object_column_map
 
 
-def get_column_header(protocol_type_term, protocol_types_dict):
-    column_header = None
-    if protocol_type_term.lower() in \
-            protocol_types_dict["nucleic acid sequencing"][SYNONYMS] \
-            + protocol_types_dict["phenotyping"][SYNONYMS] \
-            + protocol_types_dict["data acquisition"][SYNONYMS]:
-        column_header = "Assay Name"
-    elif protocol_type_term.lower() in protocol_types_dict["data collection"][SYNONYMS]:
-        column_header = "Scan Name"
-    elif protocol_type_term.lower() in protocol_types_dict["mass spectrometry"][SYNONYMS]:
-        column_header = "MS Assay Name"
-    elif protocol_type_term.lower() in protocol_types_dict["nmr spectroscopy"][SYNONYMS]:
-        column_header = "NMR Assay Name"
-    elif protocol_type_term.lower() in \
-            protocol_types_dict["data transformation"][SYNONYMS] \
-            + protocol_types_dict["sequence analysis data transformation"][SYNONYMS] \
-            + protocol_types_dict["metabolite identification"][SYNONYMS] \
-            + protocol_types_dict["protein identification"][SYNONYMS]:
-        column_header = "Data Transformation Name"
-    elif protocol_type_term.lower() in protocol_types_dict["normalization"][SYNONYMS]:
-        column_header = "Normalization Name"
-    if protocol_type_term.lower() == "unknown protocol":
-        column_header = "Unknown Protocol Name"
-    return column_header
+# def get_column_header(protocol_type_term, protocol_types_dict):
+#     column_header = None
+#     if protocol_type_term.lower() in \
+#             protocol_types_dict["nucleic acid sequencing"][SYNONYMS] \
+#             + protocol_types_dict["phenotyping"][SYNONYMS] \
+#             + protocol_types_dict["data acquisition"][SYNONYMS]:
+#         column_header = "Assay Name"
+#     elif protocol_type_term.lower() in protocol_types_dict["data collection"][SYNONYMS]:
+#         column_header = "Scan Name"
+#     elif protocol_type_term.lower() in protocol_types_dict["mass spectrometry"][SYNONYMS]:
+#         column_header = "MS Assay Name"
+#     elif protocol_type_term.lower() in protocol_types_dict["nmr spectroscopy"][SYNONYMS]:
+#         column_header = "NMR Assay Name"
+#     elif protocol_type_term.lower() in \
+#             protocol_types_dict["data transformation"][SYNONYMS] \
+#             + protocol_types_dict["sequence analysis data transformation"][SYNONYMS] \
+#             + protocol_types_dict["metabolite identification"][SYNONYMS] \
+#             + protocol_types_dict["protein identification"][SYNONYMS]:
+#         column_header = "Data Transformation Name"
+#     elif protocol_type_term.lower() in protocol_types_dict["normalization"][SYNONYMS]:
+#         column_header = "Normalization Name"
+#     if protocol_type_term.lower() == "unknown protocol":
+#         column_header = "Unknown Protocol Name"
+#     return column_header
 
 
 def get_value_columns(label, x):

--- a/isatools/isatab/utils.py
+++ b/isatools/isatab/utils.py
@@ -515,32 +515,6 @@ def get_object_column_map(isatab_header, df_columns):
     return object_column_map
 
 
-# def get_column_header(protocol_type_term, protocol_types_dict):
-#     column_header = None
-#     if protocol_type_term.lower() in \
-#             protocol_types_dict["nucleic acid sequencing"][SYNONYMS] \
-#             + protocol_types_dict["phenotyping"][SYNONYMS] \
-#             + protocol_types_dict["data acquisition"][SYNONYMS]:
-#         column_header = "Assay Name"
-#     elif protocol_type_term.lower() in protocol_types_dict["data collection"][SYNONYMS]:
-#         column_header = "Scan Name"
-#     elif protocol_type_term.lower() in protocol_types_dict["mass spectrometry"][SYNONYMS]:
-#         column_header = "MS Assay Name"
-#     elif protocol_type_term.lower() in protocol_types_dict["nmr spectroscopy"][SYNONYMS]:
-#         column_header = "NMR Assay Name"
-#     elif protocol_type_term.lower() in \
-#             protocol_types_dict["data transformation"][SYNONYMS] \
-#             + protocol_types_dict["sequence analysis data transformation"][SYNONYMS] \
-#             + protocol_types_dict["metabolite identification"][SYNONYMS] \
-#             + protocol_types_dict["protein identification"][SYNONYMS]:
-#         column_header = "Data Transformation Name"
-#     elif protocol_type_term.lower() in protocol_types_dict["normalization"][SYNONYMS]:
-#         column_header = "Normalization Name"
-#     if protocol_type_term.lower() == "unknown protocol":
-#         column_header = "Unknown Protocol Name"
-#     return column_header
-
-
 def get_value_columns(label, x):
     """ Generates the appropriate columns based on the value of the object.
     For example, if the object's .value value is an OntologyAnnotation,

--- a/isatools/model/process.py
+++ b/isatools/model/process.py
@@ -307,18 +307,18 @@ class Process(Commentable, ProcessSequenceNode, Identifiable):
         self.name = process.get('name', '')
         self.executes_protocol = indexes.get_protocol(process['executesProtocol']['@id'])
         self.load_comments(process.get('comments', []))
-        allowed_protocol_type_terms = [
-            "nucleic acid sequencing",
-            "nmr spectroscopy",
-            "mass spectrometry",
-            "nucleic acid hybridization",
-            "data transformation",
-            "data normalization"
-        ]
-        if self.executes_protocol.protocol_type.term in allowed_protocol_type_terms or (
-                self.executes_protocol.protocol_type.term == 'data collection'
-                and technology_type.term == 'DNA microarray'):
-            self.name = process['name']
+        # allowed_protocol_type_terms = [
+        #     "nucleic acid sequencing",
+        #     "nmr spectroscopy",
+        #     "mass spectrometry",
+        #     "nucleic acid hybridization",
+        #     "data transformation",
+        #     "data normalization"
+        # ]
+        # if self.executes_protocol.protocol_type.term in allowed_protocol_type_terms or (
+        #         self.executes_protocol.protocol_type.term == 'data collection'
+        #         and technology_type.term == 'DNA microarray'):
+        #     self.name = process['name']
 
         # Inputs / Outputs
         for io_data_target in ['inputs', 'outputs']:

--- a/isatools/model/process.py
+++ b/isatools/model/process.py
@@ -307,18 +307,6 @@ class Process(Commentable, ProcessSequenceNode, Identifiable):
         self.name = process.get('name', '')
         self.executes_protocol = indexes.get_protocol(process['executesProtocol']['@id'])
         self.load_comments(process.get('comments', []))
-        # allowed_protocol_type_terms = [
-        #     "nucleic acid sequencing",
-        #     "nmr spectroscopy",
-        #     "mass spectrometry",
-        #     "nucleic acid hybridization",
-        #     "data transformation",
-        #     "data normalization"
-        # ]
-        # if self.executes_protocol.protocol_type.term in allowed_protocol_type_terms or (
-        #         self.executes_protocol.protocol_type.term == 'data collection'
-        #         and technology_type.term == 'DNA microarray'):
-        #     self.name = process['name']
 
         # Inputs / Outputs
         for io_data_target in ['inputs', 'outputs']:

--- a/isatools/model/protocol.py
+++ b/isatools/model/protocol.py
@@ -283,14 +283,7 @@ def load_protocol_types_info() -> dict:
     """
     filepath = os.path.join(os.path.dirname(__file__), '..', 'resources', 'config', 'yaml', 'protocol-types.yml')
     with open(filepath) as yaml_file:
-        yaml_dict = load(yaml_file, Loader=FullLoader)
-    
-    protocol_types_dict = {}
-    for protocol, attributes in yaml_dict.items():
-        protocol_types_dict[protocol] = attributes
-        for synonym in attributes[SYNONYMS]:
-            protocol_types_dict[synonym] = attributes
-    
-    return protocol_types_dict
+        return load(yaml_file, Loader=FullLoader)
+
     
     

--- a/isatools/model/protocol.py
+++ b/isatools/model/protocol.py
@@ -2,6 +2,7 @@ import os
 from collections.abc import Iterable
 from pprint import pprint
 from yaml import load, FullLoader
+from isatools.constants import SYNONYMS
 from isatools.model.comments import Commentable
 from isatools.model.ontology_annotation import OntologyAnnotation
 from isatools.model.protocol_parameter import ProtocolParameter
@@ -282,4 +283,14 @@ def load_protocol_types_info() -> dict:
     """
     filepath = os.path.join(os.path.dirname(__file__), '..', 'resources', 'config', 'yaml', 'protocol-types.yml')
     with open(filepath) as yaml_file:
-        return load(yaml_file, Loader=FullLoader)
+        yaml_dict = load(yaml_file, Loader=FullLoader)
+    
+    protocol_types_dict = {}
+    for protocol, attributes in yaml_dict.items():
+        protocol_types_dict[protocol] = attributes
+        for synonym in attributes[SYNONYMS]:
+            protocol_types_dict[synonym] = attributes
+    
+    return protocol_types_dict
+    
+    

--- a/isatools/resources/config/yaml/protocol-types.yml
+++ b/isatools/resources/config/yaml/protocol-types.yml
@@ -84,3 +84,7 @@ protein identification:
   header: Data Transformation Name
   synonyms:
     - protein identification
+unknown protocol:
+  header: Unknown Protocol Name
+  synonyms:
+    - unknown protocol

--- a/isatools/resources/config/yaml/protocol-types.yml
+++ b/isatools/resources/config/yaml/protocol-types.yml
@@ -1,12 +1,12 @@
 sample collection:
-  header: Sample Name
+  header: 
   iri: http://purl.obolibrary.org/obo/OBI_0000659
   synonyms:
     - sample collection
     - sampling
     - aliquoting
 extraction:
-  header: Extract Name
+  header: 
   iri: http://purl.obolibrary.org/obo/OBI_0302884
   synonyms:
     - extraction
@@ -14,7 +14,7 @@ extraction:
     - intracellular metabolite extraction
     - extracelluar metabolite extraction
 labeling:
-  header: Labeled Extract Name
+  header: 
   iri: http://purl.obolibrary.org/obo/OBI_0600038
   synonyms:
     - labeling

--- a/tests/model/test_protocol.py
+++ b/tests/model/test_protocol.py
@@ -246,4 +246,4 @@ class TestFunctions(TestCase):
     def test_load_protocol_types_info(self):
         yaml_config = load_protocol_types_info()
         self.assertTrue(isinstance(yaml_config, dict))
-        self.assertTrue(len(yaml_config.keys()) == 15)
+        self.assertEqual(len(yaml_config.keys()), 16)


### PR DESCRIPTION
When I was looking into what we discussed about #553 I found what @proccaserra said about certain columns only being added if protocol types are known. I think I have improved how it is done a little, but maybe not. I figured just doing the PR would be the easiest way to illustrate things.

The first major change is to make it where the data in the protocol-types.yml file is used more directly in the `write_assay_table_files` function. Previously, it was passed to a single use function, `get_column_header`, which repeated a lot of information that was already in the `protocol_types_dict` itself. Now, that function is no longer needed. This ended up causing an issue in testing though so I modified the protocol-types.yml file a bit. 

Some of the protocol types in the file have headers, such as "Extract Name", which are already added to the assay file in another way in the `write_assay_table_files` function. This caused those headers to be repeated. I ended up simply deleting those header values and adding a check to look for null header values in the `write_assay_table_files` function to fix this. The only other place the `protocol_types_dict` is used is in the model protocol.py file to print out allowed protocol types. I'm not sure how important the header attributes are for that, so this might not be an acceptable change.

I also noticed in the process.py file in the model in the `from_assay_dict` method that there was a hard coded `allowed_protocol_type_terms` list. Initially, I thought this could also be changed to use the `protocol_types_dict`, but I don't think the logic using that hard coded list was actually doing anything anyway so I just removed it. It was only used to set the "name" attribute of the process, but there was already a line above it, `self.name = process.get('name', '')`, that would set the name regardless of protocol type.

Let me know what you guys think.

There is one more bit in the write_assay_table_files function to do with this that could possibly be improved as well, but I think it would require a more significant change. The protocol type, "nucleic acid hybridization", has special code to add 2 columns instead of 1, and I think that special code could be removed if we were willing to change the protocol_types_dict some more. If the "header" attribute were a list instead of a string then we could add the list, but then we also need a mapping from the headers to the node attribute to fill in the data for that column. Currently, they all are assumed to map to `node.name` with "nucleic acid hybridization" having the additional hard coded `node.array_design_ref`. If "header" was a dictionary that mapped the header to the attribute then the special coding for "nucleic acid hybridization" could be removed. I didn't just go on ahead and do that in this PR because I'm not too sure how important printing the allowed protocol types is. The "header" attribute already doesn't seem necessary for that purpose, so I'm not sure why it's there.