### PR TITLE
Deprecation future warnings

### DIFF
--- a/isatools/convert/isatab2w4m.py
+++ b/isatools/convert/isatab2w4m.py
@@ -225,7 +225,7 @@ def get_data_file(assay):
 
 def load_df(path):
     df = ISATAB.read_tfile(path)
-    df = df.replace(to_replace='', value=numpy.nan)
+    df = df.map(lambda x: numpy.nan if x == '' else x)
     return df
 
 
@@ -495,7 +495,7 @@ def write_data_frame(df, output_dir, template_filename, study, assay):
 
     # NA values are removed by `read_tfile()` and replaced by ''.
     # Put them back here.
-    df_with_na = df.replace(to_replace='', value=numpy.nan)
+    df_with_na = df.map(lambda x: numpy.nan if x == '' else x)
 
     # Set filename
     filename = FilenameTemplate(template_filename).substitute(s=study, a=assay)

--- a/isatools/isajson/validate.py
+++ b/isatools/isajson/validate.py
@@ -649,7 +649,7 @@ def check_term_accession_used_no_source_ref(isa_json):
 
 
 def load_config(config_dir):
-    print('CONFIG at: ', config_dir)
+    #print('CONFIG at: ', config_dir)
     import json
     configs = dict()
     for file in glob.iglob(os.path.join(config_dir, "*.json")):

--- a/isatools/isatab/dump/write.py
+++ b/isatools/isatab/dump/write.py
@@ -234,7 +234,7 @@ def write_study_table_files(inv_obj, output_dir):
         log.debug("Writing {} rows".format(len(DF.index)))
         # reset columns, replace nan with empty string, drop empty columns
         DF.columns = columns
-        DF = DF.replace('', nan)
+        DF = DF.map(lambda x: nan if x == '' else x)
         DF = DF.dropna(axis=1, how='all')
 
         with open(path.join(output_dir, study_obj.filename), 'wb') as out_fp:
@@ -534,7 +534,8 @@ def write_assay_table_files(inv_obj, output_dir, write_factor_values=False):
             log.debug("Writing {} rows".format(len(DF.index)))
             # reset columns, replace nan with empty string, drop empty columns
             DF.columns = columns
-            DF = DF.replace('', nan)
+            DF = DF.map(lambda x: nan if x == '' else x)
+
             DF = DF.dropna(axis=1, how='all')
 
             with open(path.join(

--- a/isatools/isatab/validate/rules/rules_30xx.py
+++ b/isatools/isatab/validate/rules/rules_30xx.py
@@ -191,9 +191,9 @@ def check_ontology_fields(table, cfg, tsrs):
             continue
 
         for irow in range(len(table.index)):
-            result = result and check_single_field(table.iloc[irow][icol],
-                                                   table.iloc[irow][rindx],
-                                                   table.iloc[irow][rrindx],
+            result = result and check_single_field(table.iloc[irow].iloc[icol],
+                                                   table.iloc[irow].iloc[rindx],
+                                                   table.iloc[irow].iloc[rrindx],
                                                    cfield,
                                                    table.filename)
 

--- a/isatools/net/mw2isa/__init__.py
+++ b/isatools/net/mw2isa/__init__.py
@@ -1090,7 +1090,7 @@ def mw2isa_convert(**kwargs):
 
             page = urlopen(page_url).read()
             soup = BeautifulSoup(page, "html.parser")
-            AnalysisParamTable = soup.findAll("table", {'class': "datatable2"})
+            AnalysisParamTable = soup.find_all("table", {'class': "datatable2"})
 
             # analysisid = ""
             # assay_types = []

--- a/isatools/sampletab.py
+++ b/isatools/sampletab.py
@@ -216,7 +216,7 @@ def load(FP):
             if not isnan(row["Term Source Version"]):
                 version = row["Term Source Version"]
         except TypeError:
-            pass # Value was probably NoneType...
+            print("Warning: Row 'Term Source Version': " + type(row["Term Source Version"]).__name__)
         ontology_source = OntologySource(name=row["Term Source Name"],
                                          file=row["Term Source URI"],
                                          version=version,

--- a/isatools/sampletab.py
+++ b/isatools/sampletab.py
@@ -95,7 +95,7 @@ def read_sampletab_msi(fp):
                          encoding='utf-8').dropna(axis=1, how='all')
         # load MSI section
         df = df.T  # transpose MSI section
-        df.replace(np.nan, '', regex=True, inplace=True)
+        df = df.map(lambda x: np.nan if x == '' else x)
         # Strip out the nan entries
         df.reset_index(inplace=True)
         # Reset index so it is accessible as column
@@ -210,7 +210,7 @@ def load(FP):
 
     for _, row in msi_df[["Term Source Name", "Term Source URI",
                           "Term Source Version"]]\
-            .replace('', np.nan).dropna(axis=0, how='all').iterrows():
+            .map(lambda x: np.nan if x == '' else x).dropna(axis=0, how='all').iterrows():
         version = ''
         if not isnan(row["Term Source Version"]):
             version = row["Term Source Version"]
@@ -238,10 +238,10 @@ def load(FP):
     ]
 
     try:
-        for _, row in msi_df[["Person Last Name", "Person First Name",
+        for _, row in (msi_df[["Person Last Name", "Person First Name",
                               "Person Initials", "Person Email",
-                              "Person Role"]].replace(
-                '', np.nan).dropna(axis=0, how='all').iterrows():
+                              "Person Role"]].map(lambda x: np.nan if x == '' else x).
+                dropna(axis=0, how='all').iterrows()):
             person = Person(last_name=row['Person Last Name'],
                             first_name=row['Person First Name'],
                             mid_initials=row['Person Initials'],
@@ -255,7 +255,7 @@ def load(FP):
     for i, row in msi_df[
         ["Organization Name", "Organization Address", "Organization URI",
          "Organization Email",
-         "Organization Role"]].replace('', np.nan).dropna(
+         "Organization Role"]].map(lambda x: np.nan if x == '' else x).dropna(
             axis=0, how='all').iterrows():
         ISA.comments.extend([
             Comment(name="Organization Name.{}".format(i),
@@ -633,7 +633,7 @@ def dumps(investigation):
     msi_DF = pd.concat(
         [metadata_DF, org_DF, people_DF, term_sources_DF], axis=1)
     msi_DF = msi_DF.set_index("Submission Title").T
-    msi_DF = msi_DF.replace('', np.nan)
+    msi_DF = msi_DF.map(lambda x: np.nan if x == '' else x)
     msi_memf = StringIO()
     msi_DF.to_csv(
         path_or_buf=msi_memf,
@@ -765,7 +765,8 @@ def dumps(investigation):
             else:
                 scd_DF.loc[i, characteristic_label] = characteristic.value
 
-    scd_DF = scd_DF.replace('', np.nan)
+
+    scd_DF = scd_DF.map(lambda x: np.nan if x == '' else x)
     columns = list(scd_DF.columns)
     for i, col in enumerate(columns):
         if col.endswith("Term Source REF"):

--- a/isatools/sampletab.py
+++ b/isatools/sampletab.py
@@ -212,8 +212,11 @@ def load(FP):
                           "Term Source Version"]]\
             .map(lambda x: np.nan if x == '' else x).dropna(axis=0, how='all').iterrows():
         version = ''
-        if not isnan(row["Term Source Version"]):
-            version = row["Term Source Version"]
+        try:
+            if not isnan(row["Term Source Version"]):
+                version = row["Term Source Version"]
+        except TypeError:
+            pass # Value was probably NoneType...
         ontology_source = OntologySource(name=row["Term Source Name"],
                                          file=row["Term Source URI"],
                                          version=version,


### PR DESCRIPTION
This makes some modifications where there were deprecation or future warnings.

e.g.  
`.replace('', nan)` => `.map(lambda x: nan if x == '' else x)`
`.findAll` => `.find_all`
Use of `.iloc`

More warnings remain, primarily within packages. 