### PR TITLE
Removed references to deprecated materials in favour of other_material.

### DIFF
--- a/isatools/convert/experimental/nih_dcc_flux.py
+++ b/isatools/convert/experimental/nih_dcc_flux.py
@@ -281,7 +281,7 @@ def nihdcc2isa_convert(json_path, output_path):
                 material_out.characteristics.append(material_type)
 
                 study.assays[0].samples.append(material_in)
-                study.assays[0].materials["other_material"].append(material_in)
+                study.assays[0].other_material.append(material_in)
                 try:
                     material_separation_process
                 except NameError:
@@ -300,7 +300,7 @@ def nihdcc2isa_convert(json_path, output_path):
                     value=OntologyAnnotation(term=sample_json["type"], term_source=obi),
                 )
                 material_in.characteristics.append(material_type)
-                study.assays[0].materials["other_material"].append(material_in)
+                study.assays[0].other_material.append(material_in)
 
                 data_acq_process = Process(executes_protocol=study.get_prot(sample_json["protocol.id"]))
                 data_acq_process.name = sample_json["id"]

--- a/tests/isatab/test_isatab.py
+++ b/tests/isatab/test_isatab.py
@@ -2006,7 +2006,7 @@ sample1\textraction\te2\tscanning\td2"""
                 if proc.executes_protocol.name == "genomic DNA extraction - standard procedure 4"
             )
             extract = next(
-                mat for mat in nucleotide_sequencing_assay.materials["other_material"] if mat.name == "GSM255770.e1"
+                mat for mat in nucleotide_sequencing_assay.other_material if mat.name == "GSM255770.e1"
             )
             self.assertTrue(nucl_ac_extraction_process.next_process is gen_dna_extraction_process)
             self.assertEqual(len(gen_dna_extraction_process.outputs), 1)


### PR DESCRIPTION
This fixes some calls to `.materials['other_material']` where `.other_material` should be used instead.